### PR TITLE
adds bypass for the mean with gnorm

### DIFF
--- a/examples/2dturbulence/Experiment.toml
+++ b/examples/2dturbulence/Experiment.toml
@@ -3,7 +3,7 @@ project           = "CliMAgen.jl"
 name              = "2dturbulence_test"
 savedir           = "output"
 rngseed           = 123
-logging           = true
+logging           = false
 nogpu             = false
 
 [data]
@@ -14,10 +14,11 @@ tilesize          = 128
 inchannels        = 2
 sigma_max         = 90.0
 sigma_min         = 1e-2
-mean_bypass       = false
-shift_input       = false
-shift_output      = false
-scale_mean_bypass = false
+mean_bypass       = true
+shift_input       = true
+shift_output      = true
+scale_mean_bypass = true
+gnorm             = true
 
 [optimizer]
 learning_rate     = 2e-4

--- a/examples/2dturbulence/training.jl
+++ b/examples/2dturbulence/training.jl
@@ -28,6 +28,7 @@ function run_training(params; FT=Float32, logger=nothing)
     shift_output = params.model.shift_output
     mean_bypass = params.model.mean_bypass
     scale_mean_bypass = params.model.scale_mean_bypass
+    gnorm = params.model.gnorm
     nwarmup = params.optimizer.nwarmup
     gradnorm::FT = params.optimizer.gradnorm
     learning_rate::FT = params.optimizer.learning_rate
@@ -65,6 +66,7 @@ function run_training(params; FT=Float32, logger=nothing)
         shift_output = shift_output,
         mean_bypass = mean_bypass,
         scale_mean_bypass = scale_mean_bypass,
+        gnorm = gnorm,
     )
     model = VarianceExplodingSDE(sigma_max, sigma_min, net)
     model = device(model)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
We add group norm layers for the bypass connection and hence make it nonlinear, allowing to model non-Gaussian distributions.


## To-do
Done.


## Content
Couple of updates.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevent documentation.

-->
