### PR TITLE
Rescale input

### DIFF
--- a/examples/2dturbulence/training.jl
+++ b/examples/2dturbulence/training.jl
@@ -10,9 +10,10 @@ using CliMAgen: VarianceExplodingSDE, NoiseConditionalScoreNetworkVariant
 using CliMAgen: score_matching_loss_variant
 using CliMAgen: WarmupSchedule, ExponentialMovingAverage
 using CliMAgen: train!, load_model_and_optimizer
-    
-include("../utils_wandb.jl") # for wandb logging, needs correct Python install
-include("../utils_data.jl") # for data loading
+
+package_dir = pkgdir(CliMAgen)
+include(joinpath(package_dir,"examples/utils_data.jl")) # for data loading
+include(joinpath(package_dir,"examples/utils_wandb.jl")) # for wandb logging, needs correct Python install
 
 function run_training(params; FT=Float32, logger=nothing)
     # unpack params
@@ -52,7 +53,7 @@ function run_training(params; FT=Float32, logger=nothing)
     end
 
     # set up dataset
-    dataloaders = get_data_2dturbulence(
+    dataloaders = get_data_2dturbulence_variant(
         batchsize;
         width=(tilesize, tilesize),
         stride=(tilesize, tilesize),

--- a/examples/utils_data.jl
+++ b/examples/utils_data.jl
@@ -1,4 +1,4 @@
-using MLDatasets, MLUtils, Images, DataLoaders
+using MLDatasets, MLUtils, Images, DataLoaders, Statistics
 using CliMADatasets
 
 """
@@ -68,9 +68,46 @@ function get_data_2dturbulence(batchsize; width=(32, 32), stride=(32, 32), FT=Fl
     return (; loader_train, loader_test)
 end
 
+function get_data_2dturbulence_variant(batchsize; width=(32, 32), stride=(32, 32), FT=Float32)
+    xtrain = CliMADatasets.Turbulence2D(:train; resolution=:high, Tx=FT)[:]
+    xtrain = tile_array(xtrain, width[1], width[2], stride[1], stride[2])
+
+    # fancy rescaler
+    x̄ = mean(xtrain, dims=(1, 2))
+    maxtrain_mean = maximum(x̄, dims=4)
+    mintrain_mean = minimum(x̄, dims=4)
+    Δ̄ = maxtrain_mean .- mintrain_mean
+    x̄̃ = @. 2(x̄ -  mintrain_mean) / Δ̄ - 1
+    
+    xp = xtrain .- x̄
+    maxtrain_p = maximum(xp, dims=(1, 2, 4))
+    mintrain_p = minimum(xp, dims=(1, 2, 4))
+    Δp = maxtrain_p .- mintrain_p
+    x̃p = @. 2(xp -  mintrain_p) / Δp - 1
+
+    xtrain = x̄̃ .+ x̃p
+    xtrain = MLUtils.shuffleobs(xtrain)
+    loader_train = DataLoaders.DataLoader(xtrain, batchsize)
+
+    xtest = CliMADatasets.Turbulence2D(:test; resolution=:high, Tx=FT)[:]
+    xtest = tile_array(xtest, width[1], width[2], stride[1], stride[2])
+
+    # apply the same rescaler as on training set
+    x̄ = mean(xtest, dims=(1, 2))
+    xp = xtest .- x̄
+    x̄̃ = @. 2(x̄ - mintrain_mean) / Δ̄ - 1
+    x̃p = @. 2(xp - mintrain_p) / Δp - 1
+
+    xtest = x̄̃ .+ x̃p
+    loader_test = DataLoaders.DataLoader(xtest, batchsize)
+
+    return (; loader_train, loader_test)
+end
+
 """
 Helper function that tiles an array in the first two spatial dimensions.
 
+Tiles wrap around periodically if input width is larger than spatial size of array.
 TODO!: make work generally for any spatial dimenionality.
 """
 function tile_array(A::AbstractArray, xwidth::Int, ywidth::Int, xstride::Int, ystride::Int)
@@ -78,13 +115,17 @@ function tile_array(A::AbstractArray, xwidth::Int, ywidth::Int, xstride::Int, ys
 
     # number of tiles in x and y direction
     xsize, ysize = Base.size(A)[1:2]
-    nx = floor(Int, (xsize - xwidth) / xstride)
-    ny = floor(Int, (ysize - ywidth) / ystride)
+    nx = floor(Int, abs(xsize - xwidth) / xstride)
+    ny = floor(Int, abs(ysize - ywidth) / ystride)
 
     # tile up the array in spatial directions only!
     processed_data = []
     xranges = map(k -> 1+k*xstride:xwidth+k*xstride, 0:nx)
     yranges = map(k -> 1+k*ystride:ywidth+k*ystride, 0:ny)
+
+    # if width > size of array, we wrap around periodically
+    xranges = map(x -> map(y -> mod(y, xsize) != 0 ? mod(y, xsize) : xsize, x), xranges)
+    yranges = map(x -> map(y -> mod(y, ysize) != 0 ? mod(y, ysize) : ysize, x), yranges)
     for (xr, yr) in Base.Iterators.product(xranges, yranges)
         push!(processed_data, A[xr, yr, :, :])
     end


### PR DESCRIPTION
## Purpose 
Rescale the data, so that both the distribution of spatial means and the distribution (over pixels) of the spatially varying part of the images have the same mean and variance. Then, recompute sigma_max based on this.

In our analysis scripts, we can compare the stats of the generated images to the data directly. However, we need to scale the images to be between 0 and 1 for plotting. We do this using the min/max of the training data. Lastly, we still need to clip the generated images.
