### PR TITLE
added blurry option and combined variant with regular

### DIFF
--- a/examples/2dturbulence/Experiment.toml
+++ b/examples/2dturbulence/Experiment.toml
@@ -9,6 +9,10 @@ nogpu             = false
 [data]
 batchsize         = 64
 tilesize          = 128
+kernel_std        = 0
+standard_scaling  = true
+bias_amplitude    = 0
+bias_wn           = 0
 
 [model]
 inchannels        = 2

--- a/examples/2dturbulence/analysis.jl
+++ b/examples/2dturbulence/analysis.jl
@@ -20,6 +20,10 @@ function run_analysis(params; FT=Float32, logger=nothing)
     nogpu = params.experiment.nogpu
     batchsize = params.data.batchsize
     tilesize = params.data.tilesize
+    kernel_std = params.data.kernel_std
+    standard_scaling = params.data.standard_scaling
+    bias_wn = params.data.bias_wn
+    bias_amplitude = params.data.bias_amplitude
     inchannels = params.model.inchannels
     nsamples = params.sampling.nsamples
     nimages = params.sampling.nimages
@@ -40,10 +44,14 @@ function run_analysis(params; FT=Float32, logger=nothing)
     end
 
     # set up dataset
-    dl, _ = get_data_2dturbulence_variant(
+    dl, _ = get_data_2dturbulence(
         batchsize;
         width=(tilesize, tilesize),
         stride=(tilesize, tilesize),
+        kernel_std=kernel_std,
+        standard_scaling=standard_scaling,
+        bias_wn = bias_wn,
+        bias_amplitude = bias_amplitude,
         FT=FT
     )
     xtrain = cat([x for x in dl]..., dims=4)

--- a/examples/2dturbulence/training.jl
+++ b/examples/2dturbulence/training.jl
@@ -23,6 +23,10 @@ function run_training(params; FT=Float32, logger=nothing)
     nogpu = params.experiment.nogpu
     batchsize = params.data.batchsize
     tilesize = params.data.tilesize
+    kernel_std = params.data.kernel_std
+    standard_scaling = params.data.standard_scaling
+    bias_wn = params.data.bias_wn
+    bias_amplitude = params.data.bias_amplitude
     sigma_min::FT = params.model.sigma_min
     sigma_max::FT = params.model.sigma_max
     inchannels = params.model.inchannels
@@ -54,10 +58,14 @@ function run_training(params; FT=Float32, logger=nothing)
     end
 
     # set up dataset
-    dataloaders = get_data_2dturbulence_variant(
+    dataloaders = get_data_2dturbulence(
         batchsize;
         width=(tilesize, tilesize),
         stride=(tilesize, tilesize),
+        kernel_std=kernel_std,
+        standard_scaling=standard_scaling,
+        bias_wn = bias_wn,
+        bias_amplitude = bias_amplitude,
         FT=FT
     )
 


### PR DESCRIPTION
## Purpose 

- Add option to blur images using a low pass filter with a gaussian kernel. Currently set up so that the user passes in the standard dev of the gaussian. The resulting kernel is by default `2*[2*sigma]+1` in size.  

- Depending on how we want to use these blurry images, this could be combined with a resize as well. 

- Remove separate "variant" preprocess function and combine with original.

