### PR TITLE
Diffusion bridges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@
 output/
 wandb/
 experiments/
-
+experiments/Manifest.toml
+experiments/2dturbulence/*sh
+experiments/uniform/*sh
 *~
 *.png
 *.jpg

--- a/examples/2dturbulence/analysis.jl
+++ b/examples/2dturbulence/analysis.jl
@@ -68,7 +68,7 @@ function run_analysis(params; FT=Float32, logger=nothing)
     checkpoint_path = joinpath(savedir, "checkpoint.bson")
     BSON.@load checkpoint_path model model_smooth opt opt_smooth
     model = device(model)
-
+    
     # sample from the trained model
     time_steps, Δt, init_x = setup_sampler(
         model,
@@ -103,8 +103,6 @@ function run_analysis(params; FT=Float32, logger=nothing)
     img_plot(xtrain[:, :, [1], 1:nimages], savedir, "train_images_ch1.png")
     img_plot(samples[:, :, [2], 1:nimages], savedir, "$(sampler)_images_ch2.png")
     img_plot(xtrain[:, :, [2], 1:nimages], savedir, "train_images_ch2.png")
-    model_gif(model, xtrain[:,:,:,[1]] |> device, 500, savedir, "forward.gif"; fps = 25)
-    model_gif(model, randn(FT, size(xtrain[:,:,:,[1]])) |> device, 500, savedir, "reverse.gif"; fps = 25, reverse = true)
 end
 
 function main(; experiment_toml="Experiment.toml")

--- a/examples/2dturbulence/diffusion_bridge.jl
+++ b/examples/2dturbulence/diffusion_bridge.jl
@@ -1,0 +1,203 @@
+using BSON
+using CUDA
+using Flux
+using Images
+using ProgressMeter
+using Plots
+using Random
+using Statistics
+using TOML
+
+using CliMAgen
+package_dir = pkgdir(CliMAgen)
+include(joinpath(package_dir,"examples/utils_data.jl"))
+include(joinpath(package_dir,"examples/utils_analysis.jl"))
+
+function unpack_experiment(experiment_toml; nogpu = false, FT=Float32)
+    params = TOML.parsefile(experiment_toml)
+    params = CliMAgen.dict2nt(params)
+
+    rngseed = params.experiment.rngseed
+    savedir = params.experiment.savedir
+
+    batchsize = params.data.batchsize
+    tilesize = params.data.tilesize
+    kernel_std = params.data.kernel_std
+    standard_scaling = params.data.standard_scaling
+    bias_wn = params.data.bias_wn
+    bias_amplitude = params.data.bias_amplitude
+
+    rngseed > 0 && Random.seed!(rngseed)
+
+     # set up device
+     if !nogpu && CUDA.has_cuda()
+        device = Flux.gpu
+        @info "Sampling on GPU"
+    else
+        device = Flux.cpu
+        @info "Sampling on CPU"
+    end
+
+    dl, _ = get_data_2dturbulence(
+        batchsize;
+        width=(tilesize, tilesize),
+        stride=(tilesize, tilesize),
+        kernel_std=kernel_std,
+        standard_scaling=standard_scaling,
+        bias_wn =bias_wn,
+        bias_amplitude=bias_amplitude,
+        FT=FT
+    )
+    xtrain = cat([x for x in dl]..., dims=4)
+
+    # set up model
+    checkpoint_path = joinpath(savedir, "checkpoint.bson")
+    BSON.@load checkpoint_path model model_smooth opt opt_smooth
+    model = device(model)
+    return model, xtrain |> device
+end
+
+
+function two_model_bridge(;
+                          source_toml="experiments/Experiment256_larger_bias_and_blurry.toml",
+                          target_toml="experiments/Experiment256_base_copy.toml")
+    FT = Float32
+    nogpu = false
+    nsteps = 125
+    savepath = "./"
+    nsamples = 10
+    channel = 1
+
+    forward_model, xsource = unpack_experiment(source_toml; nogpu=nogpu, FT=FT)
+    reverse_model, xtarget = unpack_experiment(target_toml; nogpu=nogpu, FT=FT)
+
+    # Determine which `k` the two sets of images begin to differ from each other
+    
+    source_spectra, k = batch_spectra(xsource |> cpu, size(xsource)[1])
+    target_spectra, k = batch_spectra(xtarget |> cpu, size(xtarget)[1])
+
+    # this is manual right now. just eyeball it.
+    cutoff_idx = 3
+    k_cutoff = FT(k[cutoff_idx])
+
+    source_power_at_cutoff = FT(mean(source_spectra[cutoff_idx,:,:]))
+    forward_t_end = FT(t_cutoff(source_power_at_cutoff, k_cutoff, forward_model.σ_max, forward_model.σ_min))
+    target_power_at_cutoff = FT(mean(target_spectra[cutoff_idx,:,:]))
+    reverse_t_end = FT(t_cutoff(target_power_at_cutoff, k_cutoff, reverse_model.σ_max, reverse_model.σ_min))
+
+    # create a bridge plot for a single image.
+    init_x = xsource[:,:,:,[3]]
+    plotname = "sde_reverse_partial.png"
+    forward_solution, reverse_solution = diffusion_bridge_simulation(forward_model,
+                                                                     reverse_model,
+                                                                     init_x,
+                                                                     nsteps;
+                                                                     forward_t_end=forward_t_end,
+                                                                     forward_solver=DifferentialEquations.RK4(),
+                                                                     forward_sde=false,
+                                                                     reverse_solver=DifferentialEquations.EM(),
+                                                                     reverse_t_end=reverse_t_end,
+                                                                     reverse_sde=true
+                                                                     )
+    # To make the plot with grayscale, we need to scale each one to between 0 and 1. 
+    images = cat(forward_solution.u..., reverse_solution.u[2:end]..., dims = (4));
+    maxes = maximum(images[:,:,[channel],:], dims = (1,2))
+    mins = minimum(images[:,:,[channel],:], dims = (1,2))
+    images = @. (images[:,:,[channel],:] - mins) / (maxes - mins)
+    img_plot(images, savepath, plotname; ncolumns = size(images)[end])
+    
+end
+
+
+function three_model_bridge(;m1_toml="experiments/Experiment256_larger_bias_and_blurry.toml",
+                             m2_toml="experiments/Experiment256_blurry_copy.toml",
+                             m3_toml="experiments/Experiment256_base_copy.toml")
+    FT = Float32
+    nogpu = false
+    nsteps = 125
+    savepath = "./"
+    nsamples = 10
+    ϵ=1.0f-5
+    nimages=4
+    channel = 1
+
+    model1, x1 = unpack_experiment(m1_toml; nogpu=nogpu, FT=FT)
+    model2, x2 = unpack_experiment(m2_toml; nogpu=nogpu, FT=FT)
+    model3, x3 = unpack_experiment(m3_toml; nogpu=nogpu, FT=FT)
+
+
+    # Determine which `k` the images begin to differ from each other
+    spectra1, k = batch_spectra(x1[:,:,:,1:nsamples] |> cpu, size(x1)[1])
+    spectra2, k = batch_spectra(x2[:,:,:,1:nsamples] |> cpu, size(x2)[1])
+    spectra3, k = batch_spectra(x3[:,:,:,1:nsamples] |> cpu, size(x3)[1])
+   # plot(k, spectra3[:,1,:][:], yaxis = :log, label = "truth")
+   # plot!(k, spectra2[:,1,:][:], label = "blurry truth")
+   # plot!(k, spectra1[:,1,:][:], label = "biased/blurry truth")
+   # savefig(joinpath(savepath, "original_spectra.png"))
+    
+    # Debiasing Bridge
+    # The models use the same noising schedule, so the t_end is the same for each.
+    cutoff_idx = 3
+    k_cutoff = FT(k[cutoff_idx])
+    # This takes a mean over channels
+    power_at_cutoff = FT(mean(spectra2[cutoff_idx,:,:]))
+    t_end = FT(t_cutoff(power_at_cutoff, k_cutoff, model2.σ_max, model2.σ_min))
+    
+    init_x = x1[:,:,:,[3]]
+    sol_m1_12, sol_m2_12 = diffusion_bridge_simulation(model1,
+                                                       model2,
+                                                       init_x,
+                                                       nsteps;
+                                                       forward_t_end=t_end,
+                                                       forward_solver=DifferentialEquations.RK4(),
+                                                       forward_sde=false,
+                                                       reverse_solver=DifferentialEquations.RK4(),
+                                                       reverse_t_end=t_end,
+                                                       reverse_sde=false)
+    
+    # Superresolution Bridge
+    # The models use the same noising schedule, so the t_end is the same for each.
+    cutoff_idx = 8
+    k_cutoff = FT(k[cutoff_idx])
+    # This takes a mean over channels
+    power_at_cutoff = FT(mean(spectra2[cutoff_idx,:,:]))
+    t_end = FT(t_cutoff(power_at_cutoff, k_cutoff, model2.σ_max, model2.σ_min))
+
+    sol_m2_23, sol_m3_23 = diffusion_bridge_simulation(model2,
+                                                       model3,
+                                                       sol_m2_12.u[end],
+                                                       nsteps;
+                                                       forward_t_end=t_end,
+                                                       forward_solver=DifferentialEquations.RK4(),
+                                                       forward_sde=false,
+                                                       reverse_solver=DifferentialEquations.EM(),
+                                                       reverse_t_end=t_end,
+                                                       reverse_sde=true)
+
+    # Rearrange the solution vectors into something we can plot
+    # Also scale the images to be [0,1] for Grayscale plotting.
+    # We do this per image, since the scale of the images grows during noising.
+    # This is not ideal, probably.                                                 
+    images12 = cat(sol_m1_12.u..., sol_m2_12.u[2:end]..., dims = (4));
+    maxes = maximum(images12[:,:,[channel],:], dims = (1,2))
+    mins = minimum(images12[:,:,[channel],:], dims = (1,2))
+    images12 = @. (images12[:,:,[channel],:] - mins) / (maxes - mins)
+
+    images23 = cat(sol_m2_23.u..., sol_m3_23.u[2:end]..., dims = (4));
+    maxes = maximum(images23[:,:,[channel],:], dims = (1,2))
+    mins = minimum(images23[:,:,[channel],:], dims = (1,2))
+    images23 = @. (images23[:,:,[channel],:] - mins) / (maxes - mins)
+
+    img_plot(images12, savepath, "debias.png"; ncolumns = size(images12)[end])
+    img_plot(images23, savepath, "superresolve.png"; ncolumns = size(images23)[end])
+ 
+    # Take a look at the spectra of all the "truth" images and the ones that we generated 
+    s_debias, k = batch_spectra(sol_m2_12.u[end][:,:,[channel],:] |> cpu, size(init_x)[1])
+    s_sr, k = batch_spectra(sol_m3_23.u[end][:,:,[channel],:]|> cpu, size(init_x)[1])
+    plot(k, spectra3[:,channel,:][:], yaxis = :log, xaxis = :log, label = "truth")
+    plot!(k, spectra2[:,channel,:][:], label = "blurry truth")
+    plot!(k, spectra1[:,channel,:][:], label = "biased/blurry truth")
+    plot!(k, s_sr[:], label = "generated truth")
+    plot!(k, s_debias[:], label =" generated blurry truth")
+    savefig(joinpath(savepath,"spectrum_comparison.png"))
+end

--- a/src/models.jl
+++ b/src/models.jl
@@ -60,11 +60,11 @@ function reverse_sde(m::AbstractDiffusionModel)
 end
 
 """
-    ClimaGen.reverse_ode
+    ClimaGen.probability_flow_ode
 
     These functions expect the input `t` to be a scalar, in order to work with DifferentialEquations.
 """
-function reverse_ode(m::AbstractDiffusionModel)
+function probability_flow_ode(m::AbstractDiffusionModel)
     function f(x, p, t) 
         t = fill!(similar(x, size(x)[end]), 1) .* t
         expand_dims(drift(m, t), ndims(x) - 1) .- expand_dims(diffusion(m, t), ndims(x) - 1) .^ 2 .* score(m, x, t) ./ 2


### PR DESCRIPTION
## Purpose
Add capability to diffuse one model to a specific time, and use a different model in the reverse. We want flexibility in terms of forward/reverse, SDE/ODE, t_end, and solvers used.

## Content 
- Adds in additional DifferentialEquations.jl wrappers which create the SDE and ODE problems for the diffusion models we work with. 
- Uses these wrappers to set up the diffusion bridge `diffusion_bridge_simulation`
- Adds a script which shows how to do two model (one leg) and three model (two leg) diffusion bridges.

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.


----
- [x] I have read and checked the items on the review checklist.
