### PR TITLE
Restart capability

### DIFF
--- a/examples/2dturbulence/training.jl
+++ b/examples/2dturbulence/training.jl
@@ -69,31 +69,50 @@ function run_training(params; FT=Float32, logger=nothing)
         FT=FT
     )
 
-    # set up model
-    net = NoiseConditionalScoreNetworkVariant(; 
-        inchannels = inchannels,
-        shift_input = shift_input,
-        shift_output = shift_output,
-        mean_bypass = mean_bypass,
-        scale_mean_bypass = scale_mean_bypass,
-        gnorm = gnorm,
-    )
-    model = VarianceExplodingSDE(sigma_max, sigma_min, net)
-    model = device(model)
-
-    # set up optimizers
-    opt = Flux.Optimise.Optimiser(
-        WarmupSchedule{FT}(
-            nwarmup 
-         ),
-        Flux.Optimise.ClipNorm(gradnorm),
-        Flux.Optimise.Adam(
-            learning_rate,
-            (beta_1, beta_2),
-            epsilon
+    # set up model and optimizers
+    checkpoint_path = joinpath(savedir, "checkpoint.bson")
+    loss_file = joinpath(savedir, "losses.txt")
+    
+    if isfile(checkpoint_path) && isfile(loss_file)
+        BSON.@load checkpoint_path model model_smooth opt opt_smooth
+        model = device(model)
+        model_smooth = device(model_smooth)
+        loss_data = DelimitedFiles.readdlm(loss_file, ',', skipstart = 1)
+        start_epoch = loss_data[end,1]+1
+    else
+        net = NoiseConditionalScoreNetworkVariant(; 
+            inchannels = inchannels,
+            shift_input = shift_input,
+            shift_output = shift_output,
+            mean_bypass = mean_bypass,
+            scale_mean_bypass = scale_mean_bypass,
+            gnorm = gnorm,
         )
-    )
-    opt_smooth = ExponentialMovingAverage(ema_rate)
+        model = VarianceExplodingSDE(sigma_max, sigma_min, net)
+        model = device(model)
+        model_smooth = deepcopy(model)
+    
+        opt = Flux.Optimise.Optimiser(
+            WarmupSchedule{FT}(
+                nwarmup 
+            ),
+            Flux.Optimise.ClipNorm(gradnorm),
+            Flux.Optimise.Adam(
+                learning_rate,
+                (beta_1, beta_2),
+                epsilon
+            )
+        )
+        opt_smooth = ExponentialMovingAverage(ema_rate)
+
+        # set up loss file
+        loss_names = reshape(["#Epoch", "Mean Train", "Spatial Train","Mean Test","Spatial Test"], (1,5))
+        open(loss_file,"w") do io
+             DelimitedFiles.writedlm(io, loss_names,',')
+        end
+
+        start_epoch=1
+    end
 
     # set up loss function
     lossfn = x -> score_matching_loss_variant(model, x)
@@ -101,12 +120,14 @@ function run_training(params; FT=Float32, logger=nothing)
     # train the model
     train!(
         model,
+        model_smooth,
         lossfn,
         dataloaders,
         opt,
         opt_smooth,
         nepochs,
         device;
+        start_epoch = start_epoch,
         savedir = savedir,
         logger = logger,
         freq_chckpt = freq_chckpt,

--- a/examples/celeba_hq/training.jl
+++ b/examples/celeba_hq/training.jl
@@ -60,31 +60,50 @@ function run_training(params; FT=Float32, logger=nothing)
         FT=FT
     )
 
-    # set up model
-    net = NoiseConditionalScoreNetworkVariant(; 
-        inchannels = inchannels,
-        shift_input = shift_input,
-        shift_output = shift_output,
-        mean_bypass = mean_bypass,
-        scale_mean_bypass = scale_mean_bypass,
-        gnorm = gnorm,
-    )
-    model = VarianceExplodingSDE(sigma_max, sigma_min, net)
-    model = device(model)
-
-    # set up optimizers
-    opt = Flux.Optimise.Optimiser(
-        WarmupSchedule{FT}(
-            nwarmup 
-         ),
-        Flux.Optimise.ClipNorm(gradnorm),
-        Flux.Optimise.Adam(
-            learning_rate,
-            (beta_1, beta_2),
-            epsilon
+    # set up model and optimizers
+    checkpoint_path = joinpath(savedir, "checkpoint.bson")
+    loss_file = joinpath(savedir, "losses.txt")
+    
+    if isfile(checkpoint_path) && isfile(loss_file)
+        BSON.@load checkpoint_path model model_smooth opt opt_smooth
+        model = device(model)
+        model_smooth = device(model_smooth)
+        loss_data = DelimitedFiles.readdlm(loss_file, ',', skipstart = 1)
+        start_epoch = loss_data[end,1]+1
+    else
+        net = NoiseConditionalScoreNetworkVariant(; 
+            inchannels = inchannels,
+            shift_input = shift_input,
+            shift_output = shift_output,
+            mean_bypass = mean_bypass,
+            scale_mean_bypass = scale_mean_bypass,
+            gnorm = gnorm,
         )
-    )
-    opt_smooth = ExponentialMovingAverage(ema_rate)
+        model = VarianceExplodingSDE(sigma_max, sigma_min, net)
+        model = device(model)
+        model_smooth = deepcopy(model)
+    
+        opt = Flux.Optimise.Optimiser(
+            WarmupSchedule{FT}(
+                nwarmup 
+            ),
+            Flux.Optimise.ClipNorm(gradnorm),
+            Flux.Optimise.Adam(
+                learning_rate,
+                (beta_1, beta_2),
+                epsilon
+            )
+        )
+        opt_smooth = ExponentialMovingAverage(ema_rate)
+
+        # set up loss file
+        loss_names = reshape(["#Epoch", "Mean Train", "Spatial Train","Mean Test","Spatial Test"], (1,5))
+        open(loss_file,"w") do io
+             DelimitedFiles.writedlm(io, loss_names,',')
+        end
+
+        start_epoch=1
+    end
 
     # set up loss function
     lossfn = x -> score_matching_loss_variant(model, x)
@@ -92,17 +111,21 @@ function run_training(params; FT=Float32, logger=nothing)
     # train the model
     train!(
         model,
+        model_smooth,
         lossfn,
         dataloaders,
         opt,
         opt_smooth,
         nepochs,
         device;
+        start_epoch = start_epoch,
         savedir = savedir,
         logger = logger,
         freq_chckpt = freq_chckpt,
     )
 end
+
+
 
 function main(; experiment_toml="Experiment.toml")
     FT = Float32

--- a/examples/cifar10/training.jl
+++ b/examples/cifar10/training.jl
@@ -58,32 +58,51 @@ function run_training(params; FT=Float32, logger=nothing)
         FT=FT
     )
 
-    # set up model
-    net = NoiseConditionalScoreNetworkVariant(; 
-        inchannels = inchannels,
-        shift_input = shift_input,
-        shift_output = shift_output,
-        mean_bypass = mean_bypass,
-        scale_mean_bypass = scale_mean_bypass,
-        gnorm = gnorm,
-        channels=[128, 256, 256, 256],
-    )
-    model = VarianceExplodingSDE(sigma_max, sigma_min, net)
-    model = device(model)
-
-    # set up optimizers
-    opt = Flux.Optimise.Optimiser(
-        WarmupSchedule{FT}(
-            nwarmup 
-         ),
-        Flux.Optimise.ClipNorm(gradnorm),
-        Flux.Optimise.Adam(
-            learning_rate,
-            (beta_1, beta_2),
-            epsilon
+    # set up model and optimizers
+    checkpoint_path = joinpath(savedir, "checkpoint.bson")
+    loss_file = joinpath(savedir, "losses.txt")
+    
+    if isfile(checkpoint_path) && isfile(loss_file)
+        BSON.@load checkpoint_path model model_smooth opt opt_smooth
+        model = device(model)
+        model_smooth = device(model_smooth)
+        loss_data = DelimitedFiles.readdlm(loss_file, ',', skipstart = 1)
+        start_epoch = loss_data[end,1]+1
+    else
+        net = NoiseConditionalScoreNetworkVariant(; 
+                                                  inchannels = inchannels,
+                                                  shift_input = shift_input,
+                                                  shift_output = shift_output,
+                                                  mean_bypass = mean_bypass,
+                                                  scale_mean_bypass = scale_mean_bypass,
+                                                  gnorm = gnorm,
+                                                  channels=[128, 256, 256, 256],
+                                                  )
+        model = VarianceExplodingSDE(sigma_max, sigma_min, net)
+        model = device(model)
+        model_smooth = deepcopy(model)
+    
+        opt = Flux.Optimise.Optimiser(
+            WarmupSchedule{FT}(
+                nwarmup 
+            ),
+            Flux.Optimise.ClipNorm(gradnorm),
+            Flux.Optimise.Adam(
+                learning_rate,
+                (beta_1, beta_2),
+                epsilon
+            )
         )
-    )
-    opt_smooth = ExponentialMovingAverage(ema_rate)
+        opt_smooth = ExponentialMovingAverage(ema_rate)
+
+        # set up loss file
+        loss_names = reshape(["#Epoch", "Mean Train", "Spatial Train","Mean Test","Spatial Test"], (1,5))
+        open(loss_file,"w") do io
+             DelimitedFiles.writedlm(io, loss_names,',')
+        end
+
+        start_epoch=1
+    end
 
     # set up loss function
     lossfn = x -> score_matching_loss_variant(model, x)
@@ -91,12 +110,14 @@ function run_training(params; FT=Float32, logger=nothing)
     # train the model
     train!(
         model,
+        model_smooth,
         lossfn,
         dataloaders,
         opt,
         opt_smooth,
         nepochs,
         device;
+        start_epoch = start_epoch,
         savedir = savedir,
         logger = logger,
         freq_chckpt = freq_chckpt,

--- a/examples/mnist/training.jl
+++ b/examples/mnist/training.jl
@@ -58,44 +58,65 @@ function run_training(params; FT=Float32, logger=nothing)
         FT=FT
     )
 
-    # set up model
-    net = NoiseConditionalScoreNetworkVariant(; 
-        inchannels = inchannels,
-        shift_input = shift_input,
-        shift_output = shift_output,
-        mean_bypass = mean_bypass,
-        scale_mean_bypass = scale_mean_bypass,
-        gnorm = gnorm,
-    )
-    model = VarianceExplodingSDE(sigma_max, sigma_min, net)
-    model = device(model)
-
-    # set up optimizers
-    opt = Flux.Optimise.Optimiser(
-        WarmupSchedule{FT}(
-            nwarmup 
-         ),
-        Flux.Optimise.ClipNorm(gradnorm),
-        Flux.Optimise.Adam(
-            learning_rate,
-            (beta_1, beta_2),
-            epsilon
+    # set up model and optimizers
+    checkpoint_path = joinpath(savedir, "checkpoint.bson")
+    loss_file = joinpath(savedir, "losses.txt")
+    
+    if isfile(checkpoint_path) && isfile(loss_file)
+        BSON.@load checkpoint_path model model_smooth opt opt_smooth
+        model = device(model)
+        model_smooth = device(model_smooth)
+        loss_data = DelimitedFiles.readdlm(loss_file, ',', skipstart = 1)
+        start_epoch = loss_data[end,1]+1
+    else
+        net = NoiseConditionalScoreNetworkVariant(; 
+            inchannels = inchannels,
+            shift_input = shift_input,
+            shift_output = shift_output,
+            mean_bypass = mean_bypass,
+            scale_mean_bypass = scale_mean_bypass,
+            gnorm = gnorm,
         )
-    )
-    opt_smooth = ExponentialMovingAverage(ema_rate)
+        model = VarianceExplodingSDE(sigma_max, sigma_min, net)
+        model = device(model)
+        model_smooth = deepcopy(model)
+    
+        opt = Flux.Optimise.Optimiser(
+            WarmupSchedule{FT}(
+                nwarmup 
+            ),
+            Flux.Optimise.ClipNorm(gradnorm),
+            Flux.Optimise.Adam(
+                learning_rate,
+                (beta_1, beta_2),
+                epsilon
+            )
+        )
+        opt_smooth = ExponentialMovingAverage(ema_rate)
 
+        # set up loss file
+        loss_names = reshape(["#Epoch", "Mean Train", "Spatial Train","Mean Test","Spatial Test"], (1,5))
+        open(loss_file,"w") do io
+             DelimitedFiles.writedlm(io, loss_names,',')
+        end
+
+        start_epoch=1
+    end
+ 
     # set up loss function
     lossfn = x -> score_matching_loss_variant(model, x)
 
     # train the model
     train!(
         model,
+        model_smooth,
         lossfn,
         dataloaders,
         opt,
         opt_smooth,
         nepochs,
         device;
+        start_epoch = start_epoch,
         savedir = savedir,
         logger = logger,
         freq_chckpt = freq_chckpt,

--- a/examples/uniform/training.jl
+++ b/examples/uniform/training.jl
@@ -61,26 +61,50 @@ function run_training(params; FT=Float32, logger=nothing)
         FT=FT
     )
 
-    # set up model
-    net = NoiseConditionalScoreNetwork(; 
-        inchannels = inchannels,
-    )
-    model = VarianceExplodingSDE(sigma_max, sigma_min, net)
-    model = device(model)
-
-    # set up optimizers
-    opt = Flux.Optimise.Optimiser(
-        WarmupSchedule{FT}(
-            nwarmup 
-         ),
-        Flux.Optimise.ClipNorm(gradnorm),
-        Flux.Optimise.Adam(
-            learning_rate,
-            (beta_1, beta_2),
-            epsilon
+    # set up model and optimizers
+    checkpoint_path = joinpath(savedir, "checkpoint.bson")
+    loss_file = joinpath(savedir, "losses.txt")
+    
+    if isfile(checkpoint_path) && isfile(loss_file)
+        BSON.@load checkpoint_path model model_smooth opt opt_smooth
+        model = device(model)
+        model_smooth = device(model_smooth)
+        loss_data = DelimitedFiles.readdlm(loss_file, ',', skipstart = 1)
+        start_epoch = loss_data[end,1]+1
+    else
+        net = NoiseConditionalScoreNetworkVariant(; 
+            inchannels = inchannels,
+            shift_input = shift_input,
+            shift_output = shift_output,
+            mean_bypass = mean_bypass,
+            scale_mean_bypass = scale_mean_bypass,
+            gnorm = gnorm,
         )
-    )
-    opt_smooth = ExponentialMovingAverage(ema_rate)
+        model = VarianceExplodingSDE(sigma_max, sigma_min, net)
+        model = device(model)
+        model_smooth = deepcopy(model)
+    
+        opt = Flux.Optimise.Optimiser(
+            WarmupSchedule{FT}(
+                nwarmup 
+            ),
+            Flux.Optimise.ClipNorm(gradnorm),
+            Flux.Optimise.Adam(
+                learning_rate,
+                (beta_1, beta_2),
+                epsilon
+            )
+        )
+        opt_smooth = ExponentialMovingAverage(ema_rate)
+
+        # set up loss file
+        loss_names = reshape(["#Epoch", "Mean Train", "Spatial Train","Mean Test","Spatial Test"], (1,5))
+        open(loss_file,"w") do io
+             DelimitedFiles.writedlm(io, loss_names,',')
+        end
+
+        start_epoch=1
+    end
 
     # set up loss function
     lossfn = x -> score_matching_loss_variant(model, x)
@@ -88,17 +112,21 @@ function run_training(params; FT=Float32, logger=nothing)
     # train the model
     train!(
         model,
+        model_smooth,
         lossfn,
         dataloaders,
         opt,
         opt_smooth,
         nepochs,
         device;
+        start_epoch = start_epoch,
         savedir = savedir,
         logger = logger,
         freq_chckpt = freq_chckpt,
     )
 end
+
+
 
 function main(; experiment_toml="Experiment.toml")
     FT = Float32

--- a/src/training.jl
+++ b/src/training.jl
@@ -1,23 +1,17 @@
 """
     ClimaGen.train!
 """
-function train!(model, lossfn, dataloaders, opt, opt_smooth, nepochs, device::Function; savedir="./output/", logger=nothing, freq_chckpt=Inf)
+function train!(model, model_smooth, lossfn, dataloaders, opt, opt_smooth, nepochs, device::Function; start_epoch=1, savedir="./output/", logger=nothing, freq_chckpt=Inf)
     # model parameters
     ps = Flux.params(model)
 
-    # setup smoothed parameters & model
-    model_smooth = deepcopy(model)
+    # setup smoothed parameters
     ps_smooth = Flux.params(model_smooth)
 
     # training loop
-    loss_names = reshape(["#Epoch", "Mean Train", "Spatial Train","Mean Test","Spatial Test"], (1,5))
-    open(joinpath(savedir, "losses.txt"),"a") do io
-        DelimitedFiles.writedlm(io, 
-                                loss_names,',')
-    end
     loss_train, loss_test = Inf, Inf
     @info "Start Training, total $(nepochs) epochs"
-    for epoch = 1:nepochs
+    for epoch = start_epoch:nepochs
         @info "Epoch $(epoch)"
 
         # update the params and compute losses


### PR DESCRIPTION
## Purpose 
Adds restart capability by
- checking if a checkpoint and loss.txt file already exist. if so, the model, model_smooth, opt, and opt_smooth are read from the file. the last epoch is read from the last line of loss.txt (perhaps better: the epoch can be stored in the checkpoint?) -> start epoch = last epoch+1
- if the checkpoint file does not already exist, the model is created from scratch, as are the optimizers. the model_smooth is still a copy of the model, it just is made in examples/training.jl rather than in src/training.jl. Also, the loss file is created. start epoch = 1

Inside training, we step now from start:nepochs. This means if you want to run longer, you just need to change `nepoch` in the original experiment toml. Additional loss terms are appended to the loss file.


## To-do

## Content
I did test locally and it seemed to work (in that it ran, and the epochs increased as expected in losses.txt). I think we save everything else that is stateful (optimizers, models...) and read them back in correctly, so it *should* be ok. The optimizer does depend on epoch (via nwarmup) but that should be saved correctly, I think?


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
