### PR TITLE
add option to change kernel size in upsampling

### DIFF
--- a/examples/2dturbulence/Experiment.toml
+++ b/examples/2dturbulence/Experiment.toml
@@ -8,7 +8,7 @@ nogpu             = false
 
 [data]
 batchsize         = 64
-tilesize          = 128
+tilesize          = 32
 kernel_std        = 0
 standard_scaling  = true
 bias_amplitude    = 0
@@ -23,6 +23,10 @@ shift_input       = true
 shift_output      = true
 scale_mean_bypass = true
 gnorm             = true
+proj_kernelsize   = 3
+outer_kernelsize  = 3
+middle_kernelsize = 3
+inner_kernelsize  = 3
 
 [optimizer]
 learning_rate     = 2e-4
@@ -34,7 +38,7 @@ ema_rate          = 0.999
 nwarmup           = 5000
 
 [training]
-nepochs           = 1
+nepochs           = 3
 freq_chckpt       = 80
 
 [sampling]
@@ -42,4 +46,4 @@ nsteps            = 1000
 nsamples          = 100
 nimages           = 25
 sampler           = "euler"
-tilesize          = 128
+tilesize          = 32

--- a/examples/2dturbulence/training.jl
+++ b/examples/2dturbulence/training.jl
@@ -21,12 +21,14 @@ function run_training(params; FT=Float32, logger=nothing)
     savedir = params.experiment.savedir
     rngseed = params.experiment.rngseed
     nogpu = params.experiment.nogpu
+
     batchsize = params.data.batchsize
     tilesize = params.data.tilesize
     kernel_std = params.data.kernel_std
     standard_scaling = params.data.standard_scaling
     bias_wn = params.data.bias_wn
     bias_amplitude = params.data.bias_amplitude
+
     sigma_min::FT = params.model.sigma_min
     sigma_max::FT = params.model.sigma_max
     inchannels = params.model.inchannels
@@ -35,6 +37,11 @@ function run_training(params; FT=Float32, logger=nothing)
     mean_bypass = params.model.mean_bypass
     scale_mean_bypass = params.model.scale_mean_bypass
     gnorm = params.model.gnorm
+    proj_kernelsize = params.model.proj_kernelsize
+    outer_kernelsize = params.model.outer_kernelsize
+    middle_kernelsize = params.model.middle_kernelsize
+    inner_kernelsize = params.model.inner_kernelsize
+
     nwarmup = params.optimizer.nwarmup
     gradnorm::FT = params.optimizer.gradnorm
     learning_rate::FT = params.optimizer.learning_rate
@@ -42,6 +49,7 @@ function run_training(params; FT=Float32, logger=nothing)
     beta_2::FT = params.optimizer.beta_2
     epsilon::FT = params.optimizer.epsilon
     ema_rate::FT = params.optimizer.ema_rate
+
     nepochs = params.training.nepochs
     freq_chckpt = params.training.freq_chckpt
 
@@ -87,6 +95,10 @@ function run_training(params; FT=Float32, logger=nothing)
             mean_bypass = mean_bypass,
             scale_mean_bypass = scale_mean_bypass,
             gnorm = gnorm,
+            proj_kernelsize = proj_kernelsize,
+            outer_kernelsize = outer_kernelsize,
+            middle_kernelsize = middle_kernelsize,
+            inner_kernelsize = inner_kernelsize
         )
         model = VarianceExplodingSDE(sigma_max, sigma_min, net)
         model = device(model)

--- a/test/test_networks.jl
+++ b/test/test_networks.jl
@@ -86,7 +86,9 @@ end
 end
 
 @testset "NCSN Variant Network" begin
-    net = CliMAgen.NoiseConditionalScoreNetworkVariant(inchannels=2)
+    net = CliMAgen.NoiseConditionalScoreNetworkVariant(inchannels=2, outer_kernelsize=5, channels=[32, 64, 128, 256])
+    @test size(Flux.params(net.layers.tconv2)[1]) == (5, 5, 128, 32)
+
     ps = Flux.params(net)
     k = 5
     x = rand(Float32, 2^k, 2^k, 2, 11)
@@ -100,11 +102,11 @@ end
     end
     @test loss isa Real
 
-    shift_input_net = CliMAgen.NoiseConditionalScoreNetworkVariant(inchannels=2, shift_input=true)
+    shift_input_net = CliMAgen.NoiseConditionalScoreNetworkVariant(inchannels=2, shift_input=true, outer_kernelsize=5,)
     Flux.loadmodel!(shift_input_net, net)
     @test net(x.-mean(x, dims = (1,2)), t) ≈ shift_input_net(x, t)
 
-    shift_output_net = CliMAgen.NoiseConditionalScoreNetworkVariant(inchannels=2, shift_output=true)
+    shift_output_net = CliMAgen.NoiseConditionalScoreNetworkVariant(inchannels=2, shift_output=true, outer_kernelsize=5,)
     Flux.loadmodel!(shift_output_net, net)
     @test (net(x, t) .-mean(net(x,t), dims = (1,2))) ≈ shift_output_net(x, t)
 


### PR DESCRIPTION
## Purpose 
Updates the upsampling to have a flexible kernel size, specified in the toml file.
Closes #86 


## To-do
Add kernel size args


## Content
We can adjust the kernelsize of the innermost tconv, middle tconv, or outer tconv, as well as the projection kernel. The naming reflects the structure of the U-net, so that's a possible issue, but if we stick with this network structure, I think it is OK.

The issue at high frequencies is generally attributed to upsampling, so I only added the feature in there:
https://proceedings.neurips.cc/paper/2021/file/96bf57c6ff19504ff145e2a32991ea96-Paper.pdf
https://openaccess.thecvf.com/content_CVPR_2020/html/Durall_Watch_Your_Up-Convolution_CNN_Based_Generative_Deep_Neural_Networks_Are_CVPR_2020_paper.html


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
