### PR TITLE
making use of dropout that is already present

### DIFF
--- a/examples/context2dturbulence/Experiment.toml
+++ b/examples/context2dturbulence/Experiment.toml
@@ -18,6 +18,7 @@ noised_channels   = 2
 context_channels  = 1
 sigma_max         = 1000.0
 sigma_min         = 1e-2
+dropout_p         = 0.0
 mean_bypass       = true
 shift_input       = true
 shift_output      = true

--- a/examples/context2dturbulence/training.jl
+++ b/examples/context2dturbulence/training.jl
@@ -31,6 +31,7 @@ function run_training(params; FT=Float32, logger=nothing)
 
     sigma_min::FT = params.model.sigma_min
     sigma_max::FT = params.model.sigma_max
+    dropout_p::FT = params.model.dropout_p
     noised_channels = params.model.noised_channels
     context_channels = params.model.context_channels
     shift_input = params.model.shift_input
@@ -91,6 +92,7 @@ function run_training(params; FT=Float32, logger=nothing)
     else
         net = NoiseConditionalScoreNetworkVariant(;
                                                   context = true,
+                                                  dropout_p = dropout_p,
                                                   noised_channels = noised_channels,
                                                   context_channels = context_channels,
                                                   shift_input = shift_input,

--- a/src/networks.jl
+++ b/src/networks.jl
@@ -108,22 +108,23 @@ end
 User Facing API for NoiseConditionalScoreNetwork architecture.
 """
 function NoiseConditionalScoreNetworkVariant(; context=false,
-                                               mean_bypass=false, 
-                                               scale_mean_bypass=false,
-                                               shift_input=false,
-                                               shift_output=false,
-                                               gnorm=false,
-                                               nspatial=2,
-                                               num_residual=8,
-                                               noised_channels=1,
-                                               context_channels=0,
-                                               channels=[32, 64, 128, 256],
-                                               embed_dim=256,
-                                               scale=30.0f0,
-                                               proj_kernelsize = 3,
-                                               outer_kernelsize = 3,
-                                               middle_kernelsize = 3,
-                                               inner_kernelsize = 3)
+                                             mean_bypass=false, 
+                                             scale_mean_bypass=false,
+                                             shift_input=false,
+                                             shift_output=false,
+                                             gnorm=false,
+                                             nspatial=2,
+                                             dropout_p = 0.0f0,
+                                             num_residual=8,
+                                             noised_channels=1,
+                                             context_channels=0,
+                                             channels=[32, 64, 128, 256],
+                                             embed_dim=256,
+                                             scale=30.0f0,
+                                             proj_kernelsize = 3,
+                                             outer_kernelsize = 3,
+                                             middle_kernelsize = 3,
+                                             inner_kernelsize = 3)
     if scale_mean_bypass & !mean_bypass
         @error("Attempting to scale the mean bypass term without adding in a mean bypass connection.")
     end
@@ -186,7 +187,7 @@ function NoiseConditionalScoreNetworkVariant(; context=false,
               
               # Residual Blocks
               resnet_blocks = 
-              [ResnetBlockVariant(channels[end], nspatial, embed_dim, 0.0f0) for _ in range(1, length=num_residual)],
+              [ResnetBlockVariant(channels[end], nspatial, embed_dim; p = dropout_p) for _ in range(1, length=num_residual)],
               
               # Decoding
               gnorm4=GroupNorm(channels[4], 32, swish),
@@ -523,7 +524,7 @@ struct ResnetBlockVariant
     dropout
 end
 
-function ResnetBlockVariant(channels::Int, nspatial::Int, nembed::Int, p=0.1f0, σ=Flux.swish)
+function ResnetBlockVariant(channels::Int, nspatial::Int, nembed::Int; p=0.1f0, σ=Flux.swish)
     # channels needs to be larger than 4
     @assert channels ÷ 4 > 0
 

--- a/test/test_networks.jl
+++ b/test/test_networks.jl
@@ -3,7 +3,7 @@
     channels = 6 => 12
     nspatial = 2
     nembed = 128
-    resnetblock = ResnetBlock(channels, nspatial, nembed)
+    resnetblock = ResnetBlock(channels, nspatial, nembed; p = 0.1f0)
     @test resnetblock isa ResnetBlock
 
     x = randn(FT, 12, 12, 6, 21)


### PR DESCRIPTION
## Purpose 
Add dropout_p to the experiment toml, and pass it along into the NCSNVariant. The resnet blocks already have dropout implement (thanks @bischtob !) and so we can just make use of that by passing along the value into the resnet block construction.

I (quickly skimmed) checked both Yang Song's code and Jonathan Ho's code, and both seem to only use dropout in the resnet blocks. This might be standard practice for Unets?
https://github.com/hojonathanho/diffusion/blob/master/diffusion_tf/models/unet.py
https://github.com/yang-song/score_sde/blob/4208a90823a06cba1fcc2d6b8974a94b37873f9e/models/ncsnpp.py

Neither mention it in their papers.
It looks lke the default value is 0.1 for LSUN and Celeba

## To-do
Check if we need to do something in training vs use of the trained model to indicate if weights should be zeroed or not. Seems like Flux just handles it based on the description
https://fluxml.ai/Flux.jl/stable/models/layers/#Test-vs.-Train
but we should test it and make sure.
