### PR TITLE
convert to using new spectrum computation

### DIFF
--- a/examples/context2dturbulence/analyze_by_batch.jl
+++ b/examples/context2dturbulence/analyze_by_batch.jl
@@ -135,7 +135,7 @@ function main(nbatches, npixels, wavenumber; experiment_toml="Experiment.toml")
         sample_κ2 = Statistics.var(cpu(samples), dims = (1,2))
         sample_κ3 = mapslices(x -> StatsBase.cumulant(x[:],3), cpu(samples), dims=[1, 2])
         sample_κ4 = mapslices(x -> StatsBase.cumulant(x[:],4), cpu(samples), dims=[1, 2])
-        sample_spectra = mapslices(x -> hcat(power_spectrum2d(x, tilesize)[1]), cpu(samples), dims =[1,2])
+        sample_spectra = mapslices(x -> hcat(power_spectrum2d(x)[1]), cpu(samples), dims =[1,2])
 
         # average instant condensation rate
         sample_icr = make_icr(cpu(samples))

--- a/examples/context2dturbulence/analyze_train_by_batch.jl
+++ b/examples/context2dturbulence/analyze_train_by_batch.jl
@@ -71,7 +71,7 @@ function main(npixels, wavenumber; experiment_toml="Experiment.toml")
         train_κ2 = Statistics.var(batch, dims = (1,2))
         train_κ3 = mapslices(x -> StatsBase.cumulant(x[:],3), batch, dims=[1, 2])
         train_κ4 = mapslices(x -> StatsBase.cumulant(x[:],4), batch, dims=[1, 2])
-        train_spectra = mapslices(x -> hcat(power_spectrum2d(x, resolution)[1]), batch, dims =[1,2])
+        train_spectra = mapslices(x -> hcat(power_spectrum2d(x)[1]), batch, dims =[1,2])
 
         # average instant condensation rate
         train_icr = make_icr(batch)

--- a/examples/context2dturbulence/diffusion_bridge.jl
+++ b/examples/context2dturbulence/diffusion_bridge.jl
@@ -74,8 +74,8 @@ function two_model_bridge(;
     reverse_model, xtarget, ctarget, scaling_target = unpack_experiment(target_toml, wavenumber; device = device,FT=FT)
                       
     # Determine which `k` the two sets of images begin to differ from each other
-    source_spectra, k = batch_spectra((xsource |> cpu)[:,:,:,[end]], size(xsource)[1])
-    target_spectra, k = batch_spectra((xtarget |> cpu)[:,:,:,[end]], size(xtarget)[1])
+    source_spectra, k = batch_spectra((xsource |> cpu)[:,:,:,[end]])
+    target_spectra, k = batch_spectra((xtarget |> cpu)[:,:,:,[end]])
                       
     # this is manual right now. just eyeball it.
     Plots.plot(Statistics.mean(source_spectra, dims = 2)[:], label = "resized 64x64")
@@ -84,11 +84,11 @@ function two_model_bridge(;
     Plots.savefig("./tmp.png")
     cutoff_idx = 10
     k_cutoff = FT(k[cutoff_idx])
-                      
+    N = FT(size(xsource)[1])
     source_power_at_cutoff = FT(mean(source_spectra[cutoff_idx,:,:]))
-    forward_t_end = FT(t_cutoff(source_power_at_cutoff, k_cutoff, forward_model.σ_max, forward_model.σ_min))
+    forward_t_end = FT(t_cutoff(source_power_at_cutoff, k_cutoff, N, forward_model.σ_max, forward_model.σ_min))
     target_power_at_cutoff = FT(mean(target_spectra[cutoff_idx,:,:]))
-    reverse_t_end = FT(t_cutoff(target_power_at_cutoff, k_cutoff, reverse_model.σ_max, reverse_model.σ_min))
+    reverse_t_end = FT(t_cutoff(target_power_at_cutoff, k_cutoff, N, reverse_model.σ_max, reverse_model.σ_min))
 
     # create a bridge plot for a single image.
     idx = [5,10,15, 20, 25, 30]#size(xsource)[end]


### PR DESCRIPTION
## Purpose 
Update our power spectrum computation to not use the 2pi k^2 factor, and to also return the wavenumber rather than the spatial frequency.

Propagate these changes to `batch_spectra`, `spectrum_plot`, and `t_cutoff`.

This is part of a process to remove duplicate material spread over multiple open big PRs and merge things bit by bit.
