### PR TITLE
Prevent divide by zero

### DIFF
--- a/examples/utils_data.jl
+++ b/examples/utils_data.jl
@@ -229,7 +229,10 @@ function get_data_context2dturbulence(batchsize;
         if standard_scaling
             maxtrain = maximum(xtrain, dims=(1, 2, 4))
             mintrain = minimum(xtrain, dims=(1, 2, 4))
-            scaling = StandardScaling{FT}(mintrain, maxtrain)
+            Δ = maxtrain .- mintrain
+            # To prevent dividing by zero
+            Δ[Δ .== 0] .= FT(1)
+            scaling = StandardScaling{FT}(mintrain, Δ)
         else
             #scale means and spatial variations separately
             x̄ = mean(xtrain, dims=(1, 2))
@@ -240,6 +243,10 @@ function get_data_context2dturbulence(batchsize;
             maxtrain_p = maximum(xp, dims=(1, 2, 4))
             mintrain_p = minimum(xp, dims=(1, 2, 4))
             Δp = maxtrain_p .- mintrain_p
+
+            # To prevent dividing by zero
+            Δ̄[Δ̄ .== 0] .= FT(1)
+            Δp[Δp .== 0] .= FT(1)
             scaling = MeanSpatialScaling{FT}(mintrain_mean, Δ̄, mintrain_p, Δp)
         end
         JLD2.save_object(preprocess_params_file, scaling)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using CUDA
 using Flux
 using Test
 using Random
-using Statistics: mean
+using Statistics
 
 FT = Float32
 

--- a/test/test_preprocessing.jl
+++ b/test/test_preprocessing.jl
@@ -2,7 +2,10 @@
     @testset "Scaling transforms" begin
         FT = Float32
         x = randn(FT,(64,64,3,100))
-        scaling = StandardScaling{FT}(minimum(x, dims = (1,2,4)), maximum(x, dims = (1,2,4)))
+        min_values = minimum(x, dims = (1,2,4))
+        max_values = maximum(x, dims = (1,2,4))
+        Δ = max_values .- min_values
+        scaling = StandardScaling{FT}(min_values, Δ)
         @test x ≈ invert_preprocessing(apply_preprocessing(x, scaling), scaling)
 
         x̄ = mean(x, dims=(1, 2))
@@ -13,6 +16,35 @@
         max_p = maximum(xp, dims=(1, 2, 4))
         min_p = minimum(xp, dims=(1, 2, 4))
         Δp = max_p .- min_p
+        scaling = MeanSpatialScaling{FT}(min_mean, Δ̄, min_p, Δp)
+        @test x ≈ invert_preprocessing(apply_preprocessing(x, scaling), scaling)
+
+
+        # Test in case where a field is constant
+        x[:,:,1,:] .= FT(0)
+        # zero spatial mean
+        x[:,:,2,:] .=  x[:,:,2,:] .- Statistics.mean(x[:,:,2,:], dims = (1,2))
+        # zero deviations
+        x[:,:,3,1:50] .=  FT(2)
+        x[:,:,3,50:100] .=  FT(3)
+
+        min_values = minimum(x, dims = (1,2,4))
+        max_values = maximum(x, dims = (1,2,4))
+        Δ[Δ .== 0] .= FT(1)
+        scaling = StandardScaling{FT}(min_values, Δ)
+        @test x ≈ invert_preprocessing(apply_preprocessing(x, scaling), scaling)
+
+        x̄ = mean(x, dims=(1, 2))
+        max_mean = maximum(x̄, dims=4)
+        min_mean = minimum(x̄, dims=4)
+        Δ̄ = max_mean .- min_mean
+        Δ̄[Δ̄ .== 0] .= FT(1)
+
+        xp = x .- x̄
+        max_p = maximum(xp, dims=(1, 2, 4))
+        min_p = minimum(xp, dims=(1, 2, 4))
+        Δp = max_p .- min_p
+        Δp[Δp .== 0] .= FT(1)
         scaling = MeanSpatialScaling{FT}(min_mean, Δ̄, min_p, Δp)
         @test x ≈ invert_preprocessing(apply_preprocessing(x, scaling), scaling)
 


### PR DESCRIPTION
## Purpose 
Prevent dividing by zero in preprocessing.
 Part of a series of small PRs to bring all the latest changes to main.